### PR TITLE
Documentação da API com DRF-SPECTACULAR

### DIFF
--- a/api/swagger/__init__.py
+++ b/api/swagger/__init__.py
@@ -1,8 +1,19 @@
-from.user_mixin_swagger import UserCreateSwaggerMixin
-from .authentication_mixin_swagger import MyTokenObtainPairSwaggerMixin, LogoutSwaggerMixin
+from .user_mixin_swagger import (
+    MasterUserCreateSwaggerMixin,
+    MasterUserListSwaggerMixin,
+    MasterUserUpdateSwaggerMixin,
+    MasterUserDeleteSwaggerMixin,
+)
+from .authentication_mixin_swagger import (
+    MyTokenObtainPairSwaggerMixin,
+    LogoutSwaggerMixin,
+)
 
 __All__ = [
-    'UserCreateSwaggerMixin',
-    'MyTokenObtainPairSwaggerMixin',
-    'LogoutSwaggerMixin',
+    "MasterUserCreateSwaggerMixin",
+    "MasterUserListSwaggerMixin",
+    "MasterUserUpdateSwaggerMixin",
+    "MasterUserDeleteSwaggerMixin",
+    "MyTokenObtainPairSwaggerMixin",
+    "LogoutSwaggerMixin",
 ]

--- a/api/swagger/__init__.py
+++ b/api/swagger/__init__.py
@@ -1,19 +1,33 @@
+from .authentication_mixin_swagger import (
+    MyTokenObtainPairSwaggerMixin,
+    LogoutSwaggerMixin,
+)
+
 from .user_mixin_swagger import (
     MasterUserCreateSwaggerMixin,
     MasterUserListSwaggerMixin,
     MasterUserUpdateSwaggerMixin,
     MasterUserDeleteSwaggerMixin,
 )
-from .authentication_mixin_swagger import (
-    MyTokenObtainPairSwaggerMixin,
-    LogoutSwaggerMixin,
+
+from .company_mixin_swagger import (
+    CompanyUserCreateSwaggerMixin,
+    CompanyUserListSwaggerMixin,
+    CompanyUserUpdateSwaggerMixin,
+    CompanyUserDeleteSwaggerMixin,
 )
 
+
 __All__ = [
+    "MyTokenObtainPairSwaggerMixin",
+    "LogoutSwaggerMixin",
     "MasterUserCreateSwaggerMixin",
     "MasterUserListSwaggerMixin",
     "MasterUserUpdateSwaggerMixin",
     "MasterUserDeleteSwaggerMixin",
-    "MyTokenObtainPairSwaggerMixin",
-    "LogoutSwaggerMixin",
+    "CompanyUserCreateSwaggerMixin",
+    "CompanyUserListSwaggerMixin",
+    "CompanyUserUpdateSwaggerMixin",
+    "CompanyUserDeleteSwaggerMixin",
+    
 ]

--- a/api/swagger/__init__.py
+++ b/api/swagger/__init__.py
@@ -17,6 +17,13 @@ from .company_mixin_swagger import (
     CompanyUserDeleteSwaggerMixin,
 )
 
+from .employee_mixin_swagger import (
+    EmployeeUserCreateSwaggerMixin,
+    EmployeeUserListSwaggerMixin,
+    EmployeeUserUpdateSwaggerMixin,
+    EmployeeUserDeleteSwaggerMixin,
+    EmployeeTransferSwaggerMixin,
+)
 
 __All__ = [
     "MyTokenObtainPairSwaggerMixin",
@@ -29,5 +36,10 @@ __All__ = [
     "CompanyUserListSwaggerMixin",
     "CompanyUserUpdateSwaggerMixin",
     "CompanyUserDeleteSwaggerMixin",
+    "EmployeeUserCreateSwaggerMixin",
+    "EmployeeUserListSwaggerMixin",
+    "EmployeeUserUpdateSwaggerMixin",
+    "EmployeeUserDeleteSwaggerMixin",
+    "EmployeeTransferSwaggerMixin",
     
 ]

--- a/api/swagger/authentication_mixin_swagger.py
+++ b/api/swagger/authentication_mixin_swagger.py
@@ -66,6 +66,7 @@ class LogoutSwaggerMixin:
         if hasattr(cls, 'post'):
             cls.post = extend_schema(
                 tags=["Autenticação"],
+                auth=[{"Bearer": []}],
                 description="Desloga um usuário e invalida o token de atualização.",
                 summary="Desloga o usuário e invalida o token de atualização.",
                 request=OpenApiTypes.OBJECT,

--- a/api/swagger/company_mixin_swagger.py
+++ b/api/swagger/company_mixin_swagger.py
@@ -108,7 +108,7 @@ class CompanyUserListSwaggerMixin:
                                             "previous": None,
                                             "results": [
                                                 {
-                                                    "id": 6,
+                                                    "id": 1,
                                                     "username": "abc",
                                                     "email": "contato@empresaabc.com",
                                                     "name": "Empresa ABC Ltda",
@@ -126,7 +126,7 @@ class CompanyUserListSwaggerMixin:
                                                     },
                                                 },
                                                 {
-                                                    "id": 8,
+                                                    "id": 2,
                                                     "username": "abc2",
                                                     "email": "contato2@empresaabc.com",
                                                     "name": "Empresa ABC Ltda2",

--- a/api/swagger/company_mixin_swagger.py
+++ b/api/swagger/company_mixin_swagger.py
@@ -1,0 +1,326 @@
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiExample,
+    OpenApiResponse,
+    OpenApiParameter,
+)
+from drf_spectacular.types import OpenApiTypes
+
+
+class CompanyUserCreateSwaggerMixin:
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "post"):
+            cls.post = extend_schema(
+                tags=["Empresa"],
+                summary="Cria uma nova empresa.",
+                methods=["POST"],
+                auth=[{"Bearer": []}],
+                description="Faz o cadastro de uma nova empresa no sistema.",
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    201: OpenApiResponse(
+                        description="Usuário criado com sucesso",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "id": 1,
+                                    "username": "abc3",
+                                    "email": "contato3@empresaabc.com",
+                                    "name": "Empresa ABC Ltda3",
+                                    "cnpj": "12345678000193",
+                                    "company_phone": "81999998888",
+                                    "company_site": "https://www.empresaabc.com",
+                                    "company_endereco": {
+                                        "rua": "Av. Principal",
+                                        "numero": "1000",
+                                        "bairro": "Centro",
+                                        "cidade": "Recife",
+                                        "estado": "PE",
+                                        "cep": "50000-000",
+                                    },
+                                },
+                            )
+                        ],
+                    ),
+                    400: OpenApiResponse(
+                        description="Erro no registro",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de erro",
+                                value={"message": "Erro ao criar empresa."},
+                            )
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={
+                            "username": "abc3",
+                            "name": "Empresa ABC Ltda3",
+                            "password": "Ativos@2025",
+                            "email": "contato3@empresaabc.com",
+                            "cnpj": "12345678000193",
+                            "phone": "81999998888",
+                            "site": "https://www.empresaabc.com",
+                            "endereco": {
+                                "rua": "Av. Principal",
+                                "numero": "1000",
+                                "bairro": "Centro",
+                                "cidade": "Recife",
+                                "estado": "PE",
+                                "cep": "50000-000",
+                            },
+                        },
+                    )
+                ],
+            )(cls.post)
+
+
+class CompanyUserListSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "get"):
+            cls.get = extend_schema(
+                tags=["Empresa"],
+                summary="Lista todas as empresas.",
+                methods=["GET"],
+                description="Retorna uma lista de todas as empresas cadastradas no sistema.",
+                responses={
+                    200: OpenApiResponse(
+                        description="Usuários listados com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "result": [
+                                        {
+                                            "count": 2,
+                                            "next": None,
+                                            "previous": None,
+                                            "results": [
+                                                {
+                                                    "id": 6,
+                                                    "username": "abc",
+                                                    "email": "contato@empresaabc.com",
+                                                    "name": "Empresa ABC Ltda",
+                                                    "cnpj": "12345678000190",
+                                                    "company_id": "4762a0e6-3b98-4c2b-ba0f-1c8ead74c010",
+                                                    "company_phone": "81999998888",
+                                                    "company_site": "https://www.empresaabc.com",
+                                                    "company_endereco": {
+                                                        "cep": "50000-000",
+                                                        "rua": "Av. Principal",
+                                                        "bairro": "Centro",
+                                                        "cidade": "Recife",
+                                                        "estado": "PE",
+                                                        "numero": "1000",
+                                                    },
+                                                },
+                                                {
+                                                    "id": 8,
+                                                    "username": "abc2",
+                                                    "email": "contato2@empresaabc.com",
+                                                    "name": "Empresa ABC Ltda2",
+                                                    "cnpj": "12345678000192",
+                                                    "company_id": "c4a837c2-c63d-4629-9b1d-408e2994edcd",
+                                                    "company_phone": "81999998888",
+                                                    "company_site": "https://www.empresaabc.com",
+                                                    "company_endereco": {
+                                                        "cep": "50000-000",
+                                                        "rua": "Av. Principal",
+                                                        "bairro": "Centro",
+                                                        "cidade": "Recife",
+                                                        "estado": "PE",
+                                                        "numero": "1000",
+                                                    },
+                                                },
+                                            ],
+                                        }
+                                    ]
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.get)
+
+
+class CompanyUserUpdateSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "patch"):
+            cls.patch = extend_schema(
+                tags=["Empresa"],
+                description="Atualiza a empresa no sistema.",
+                summary="Atualiza a empresa.",
+                methods=["PATCH"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário empresa a ser atualizado.",
+                        required=True,
+                    ),
+                ],
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    202: OpenApiResponse(
+                        description="Usuário atualizado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "id": 1,
+                                    "username": "abc3",
+                                    "email": "contato3@empresaabc.com",
+                                    "name": "Empresa ABC Ltda3",
+                                    "cnpj": "12345678000193",
+                                    "company_phone": "81999998888",
+                                    "company_site": "https://www.empresaabc.com",
+                                    "company_endereco": {
+                                        "rua": "Av. Principal",
+                                        "numero": "1000",
+                                        "bairro": "Centro",
+                                        "cidade": "Recife",
+                                        "estado": "PE",
+                                        "cep": "50000-000",
+                                    },
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={
+                            "username": "abc3",
+                            "name": "Empresa ABC Ltda3",
+                            "password": "Ativos@2025",
+                            "email": "contato3@empresaabc.com",
+                            "cnpj": "12345678000193",
+                            "phone": "81999998888",
+                            "site": "https://www.empresaabc.com",
+                            "endereco": {
+                                "rua": "Av. Principal",
+                                "numero": "1000",
+                                "bairro": "Centro",
+                                "cidade": "Recife",
+                                "estado": "PE",
+                                "cep": "50000-000",
+                            },
+                        },
+                        request_only=True,
+                    )
+                ],
+            )(cls.patch)
+
+
+class CompanyUserDeleteSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "delete"):
+            cls.delete = extend_schema(
+                tags=["Empresa"],
+                description="Deleta o usuário empresa.",
+                summary="Deleta o usuário.",
+                methods=["DELETE"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário a ser deletado.",
+                        required=True,
+                    ),
+                ],
+                responses={
+                    204: OpenApiResponse(
+                        description="Usuário deletado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.delete)

--- a/api/swagger/employee_mixin_swagger.py
+++ b/api/swagger/employee_mixin_swagger.py
@@ -1,0 +1,413 @@
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiExample,
+    OpenApiResponse,
+    OpenApiParameter,
+)
+from drf_spectacular.types import OpenApiTypes
+
+
+class EmployeeUserCreateSwaggerMixin:
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "post"):
+            cls.post = extend_schema(
+                tags=["Funcionário"],
+                summary="Cria um novo funcionário.",
+                methods=["POST"],
+                auth=[{"Bearer": []}],
+                description="Faz o cadastro de um novo funcionário no sistema.",
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    201: OpenApiResponse(
+                        description="Usuário criado com sucesso",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "id": 1,
+                                    "username": "funcionario_joao",
+                                    "email": "joao@empresaabc.com",
+                                    "name": "João da Silva",
+                                    "cpf": "98765432102",
+                                    "employee_id": "28af1d08-c435-4330-97cb-db947d0b4bd9",
+                                    "employee_phone": "81999995555",
+                                    "employee_linkedin": "https://www.linkedin.com/in/joaosilva",
+                                    "employee_endereco": {
+                                        "rua": "Rua das Flores",
+                                        "numero": "123",
+                                        "bairro": "Boa Viagem",
+                                        "cidade": "Recife",
+                                        "estado": "PE",
+                                        "cep": "51020-000",
+                                    },
+                                },
+                            )
+                        ],
+                    ),
+                    400: OpenApiResponse(
+                        description="Erro no registro",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de erro",
+                                value={"message": "Erro ao criar funcionário."},
+                            )
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={
+                            "username": "funcionario_joao_2",
+                            "name": "João da Silva2",
+                            "password": "Senha@123",
+                            "email": "joao2@empresaabc.com",
+                            "cpf": "98765432102",
+                            "phone": "81999995555",
+                            "linkedin": "https://www.linkedin.com/in/joaosilva",
+                            "endereco": {
+                                "rua": "Rua das Flores",
+                                "numero": "123",
+                                "bairro": "Boa Viagem",
+                                "cidade": "Recife",
+                                "estado": "PE",
+                                "cep": "51020-000",
+                            },
+                            "company_id": "c4a837c2-c63d-4629-9b1d-408e2994edcd",
+                        },
+                    )
+                ],
+            )(cls.post)
+
+
+class EmployeeUserListSwaggerMixin:
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "get"):
+            cls.get = extend_schema(
+                tags=["Funcionário"],
+                summary="Lista todos os funcionários.",
+                methods=["GET"],
+                description="Retorna uma lista de todos funcionários cadastradas no sistema.",
+                responses={
+                    200: OpenApiResponse(
+                        description="Usuários listados com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "result": [
+                                        {
+                                            "count": 2,
+                                            "next": None,
+                                            "previous": None,
+                                            "results": [
+                                                {
+                                                    "count": 1,
+                                                    "next": None,
+                                                    "previous": None,
+                                                    "results": [
+                                                        {
+                                                            "id": 1,
+                                                            "username": "funcionario_joao",
+                                                            "email": "joao@empresaabc.com",
+                                                            "name": "João da Silva",
+                                                            "cpf": "98765432100",
+                                                            "employee_id": "5304400b-78c8-4594-957a-5e47af2d0b15",
+                                                            "employee_phone": "81999995555",
+                                                            "employee_linkedin": "https://www.linkedin.com/in/joaosilva",
+                                                            "employee_endereco": {
+                                                                "cep": "51020-000",
+                                                                "rua": "Rua das Flores",
+                                                                "bairro": "Boa Viagem",
+                                                                "cidade": "Recife",
+                                                                "estado": "PE",
+                                                                "numero": "123",
+                                                            },
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "username": "funcionario_joao",
+                                                            "email": "joao@empresaabc.com",
+                                                            "name": "João da Silva",
+                                                            "cpf": "98765432100",
+                                                            "employee_id": "5304400b-78c8-4594-957a-5e47af2d0b15",
+                                                            "employee_phone": "81999995555",
+                                                            "employee_linkedin": "https://www.linkedin.com/in/joaosilva",
+                                                            "employee_endereco": {
+                                                                "cep": "51020-000",
+                                                                "rua": "Rua das Flores",
+                                                                "bairro": "Boa Viagem",
+                                                                "cidade": "Recife",
+                                                                "estado": "PE",
+                                                                "numero": "123",
+                                                            },
+                                                        },
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ]
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.get)
+
+
+class EmployeeUserUpdateSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "patch"):
+            cls.patch = extend_schema(
+                tags=["Funcionário"],
+                description="Atualiza um funcionário no sistema.",
+                summary="Atualiza um funcionáro.",
+                methods=["PATCH"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário funcionário a ser atualizado.",
+                        required=True,
+                    ),
+                ],
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    202: OpenApiResponse(
+                        description="Usuário atualizado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "id": 1,
+                                    "username": "funcionario_joao_atualizado",
+                                    "email": "joao@empresaabc.com",
+                                    "name": "João da Silva",
+                                    "cpf": "98765432100",
+                                    "employee_id": "5304400b-78c8-4594-957a-5e47af2d0b15",
+                                    "employee_phone": "81999995555",
+                                    "employee_linkedin": "https://www.linkedin.com/in/joaosilva",
+                                    "employee_endereco": {
+                                        "rua": "Rua das Flores",
+                                        "numero": "123",
+                                        "bairro": "Boa Viagem",
+                                        "cidade": "Recife",
+                                        "estado": "PE",
+                                        "cep": "51020-000",
+                                    },
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={
+                            "username": "funcionario_joao_atualizado",
+                            "name": "João da Silva",
+                            "password": "Senha@123",
+                            "email": "joao@empresaabc.com",
+                            "cpf": "98765432100",
+                            "phone": "81999995555",
+                            "linkedin": "https://www.linkedin.com/in/joaosilva",
+                            "endereco": {
+                                "rua": "Rua das Flores",
+                                "numero": "123",
+                                "bairro": "Boa Viagem",
+                                "cidade": "Recife",
+                                "estado": "PE",
+                                "cep": "51020-000",
+                            },
+                        },
+                        request_only=True,
+                    )
+                ],
+            )(cls.patch)
+
+
+class EmployeeUserDeleteSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "delete"):
+            cls.delete = extend_schema(
+                tags=["Funcionário"],
+                description="Deleta o usuário funcionário.",
+                summary="Deleta o usuário.",
+                methods=["DELETE"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário a ser deletado.",
+                        required=True,
+                    ),
+                ],
+                responses={
+                    204: OpenApiResponse(
+                        description="Usuário deletado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.delete)
+
+
+class EmployeeTransferSwaggerMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "patch"):
+            cls.patch = extend_schema(
+                tags=["Funcionário"],
+                description="Transfere um funcionário para outra empresa.",
+                summary="Transfere um funcionáro.",
+                methods=["PATCH"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário funcionário a ser transferido.",
+                        required=True,
+                    ),
+                ],
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    202: OpenApiResponse(
+                        description="Usuário transferido com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "message": "Funcionário transferido com sucesso",
+                                    "employee_id": "5304400b-78c8-4594-957a-5e47af2d0b15",
+                                    "employee_username": "funcionario_joao",
+                                    "employee_name": "João da Silva",
+                                    "employee_email": "joao@empresaabc.com",
+                                    "employee_cpf": "98765432100",
+                                    "old_company_id": "c4a837c2-c63d-4629-9b1d-408e2994edcd",
+                                    "new_company_id": "4762a0e6-3b98-4c2b-ba0f-1c8ead74c010",
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={"company_id": "4762a0e6-3b98-4c2b-ba0f-1c8ead74c010"},
+                        request_only=True,
+                    )
+                ],
+            )(cls.patch)

--- a/api/swagger/user_mixin_swagger.py
+++ b/api/swagger/user_mixin_swagger.py
@@ -28,21 +28,20 @@ class MasterUserCreateSwaggerMixin:
                             OpenApiExample(
                                 name="Exemplo de resposta de sucesso",
                                 value={
-                                    "id": 1,
-                                    "is_superuser": True,
-                                    "first_name": "Clint",
-                                    "last_name": "Eastwood",
-                                    "username": "clint",
-                                    "name": "Clint Eastwood",
-                                    "email": "clint@example.com",
-                                    "cpf": "02458695412",
-                                    "date_joined": "19-04-2025 11:51",
-                                    "last_login": "19-04-2025 11:51",
-                                    "created_at": "19-04-2025 11:51",
-                                    "updated_at": "19-04-2025 11:51",
-                                    "is_master": True,
-                                    "is_staff": True,
-                                    "is_active": True,
+                                    "message": "Usuário criado com sucesso",
+                                    "result": {
+                                        "id": 16,
+                                        "first_name": "Lemmy",
+                                        "last_name": "Kilmister",
+                                        "username": "lemmy",
+                                        "name": "Lemmy Kilmister",
+                                        "email": "motorhead@email.com",
+                                        "cpf": "12345678902",
+                                        "date_joined": "23-04-2025 22:43",
+                                        "created_at": "23-04-2025 22:43",
+                                        "is_superuser": True,
+                                        "is_master": True,
+                                    },
                                 },
                             )
                         ],
@@ -62,11 +61,11 @@ class MasterUserCreateSwaggerMixin:
                     OpenApiExample(
                         name="Exemplo de requisição",
                         value={
-                            "username": "clint",
-                            "name": "Clint Eastwood",
-                            "password": "robson123",
-                            "email": "clint@example.com",
-                            "cpf": "02458695412",
+                            "username": "lemmy",
+                            "name": "Lemmy Kilmister",
+                            "password": "lemmy123",
+                            "email": "motorhead@email.com",
+                            "cpf": "12345678902",
                         },
                     )
                 ],
@@ -263,62 +262,63 @@ class MasterUserUpdateSwaggerMixin:
                 ],
             )(cls.patch)
 
+
 class MasterUserDeleteSwaggerMixin:
-    
-        def __init_subclass__(cls, **kwargs):
-            super().__init_subclass__(**kwargs)
-    
-            if hasattr(cls, "delete"):
-                cls.delete = extend_schema(
-                    tags=["Usuário"],
-                    auth=[{"Bearer": []}],
-                    description="Deleta o usuário master.",
-                    summary="Deleta o usuário.",
-                    methods=["DELETE"],
-                    parameters=[
-                        OpenApiParameter(
-                            name="id",
-                            location=OpenApiParameter.PATH,
-                            type=OpenApiTypes.UUID,
-                            description="ID do usuário a ser deletado.",
-                            required=True,
-                        ),
-                    ],
-                    responses={
-                        204: OpenApiResponse(
-                            description="Usuário deletado com sucesso.",
-                            response=OpenApiTypes.OBJECT,
-                            examples=[
-                                OpenApiExample(
-                                    name="Exemplo de resposta de sucesso",
-                                    value={},
-                                    response_only=True,
-                                ),
-                            ],
-                        ),
-                        401: OpenApiResponse(
-                            description="Usuário não autorizado.",
-                            response=OpenApiTypes.OBJECT,
-                            examples=[
-                                OpenApiExample(
-                                    name="Usuário não autorizado",
-                                    value={
-                                        "detail": "Authentication credentials were not provided."
-                                    },
-                                    response_only=True,
-                                ),
-                            ],
-                        ),
-                        404: OpenApiResponse(
-                            description="Usuário não encontrado.",
-                            response=OpenApiTypes.OBJECT,
-                            examples=[
-                                OpenApiExample(
-                                    name="Usuário não encontrado",
-                                    value={"detail": "Usuário não encontrado."},
-                                    response_only=True,
-                                ),
-                            ],
-                        ),
-                    },
-                )(cls.delete)
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "delete"):
+            cls.delete = extend_schema(
+                tags=["Usuário"],
+                auth=[{"Bearer": []}],
+                description="Deleta o usuário master.",
+                summary="Deleta o usuário.",
+                methods=["DELETE"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário a ser deletado.",
+                        required=True,
+                    ),
+                ],
+                responses={
+                    204: OpenApiResponse(
+                        description="Usuário deletado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.delete)

--- a/api/swagger/user_mixin_swagger.py
+++ b/api/swagger/user_mixin_swagger.py
@@ -15,6 +15,7 @@ class MasterUserCreateSwaggerMixin:
         if hasattr(cls, "post"):
             cls.post = extend_schema(
                 tags=["Usuário"],
+                auth=[{"Bearer": []}],
                 summary="Cria um usuário",
                 methods=["POST"],
                 description="Faz o cadastro de um novo usuário no sistema.",
@@ -80,9 +81,9 @@ class MasterUserListSwaggerMixin:
         if hasattr(cls, "get"):
             cls.get = extend_schema(
                 tags=["Usuário"],
+                auth=[{"Bearer": []}],
                 description="Lista todos os usuários master do sistema.",
                 summary="Lista todos os usuários.",
-                auth=[{"Bearer": []}],
                 methods=["GET"],
                 responses={
                     200: OpenApiResponse(
@@ -173,9 +174,9 @@ class MasterUserUpdateSwaggerMixin:
         if hasattr(cls, "patch"):
             cls.patch = extend_schema(
                 tags=["Usuário"],
+                auth=[{"Bearer": []}],
                 description="Atualiza o usuário master.",
                 summary="Atualiza o usuário.",
-                auth=[{"Bearer": []}],
                 methods=["PATCH"],
                 parameters=[
                     OpenApiParameter(
@@ -270,9 +271,9 @@ class MasterUserDeleteSwaggerMixin:
             if hasattr(cls, "delete"):
                 cls.delete = extend_schema(
                     tags=["Usuário"],
+                    auth=[{"Bearer": []}],
                     description="Deleta o usuário master.",
                     summary="Deleta o usuário.",
-                    auth=[{"Bearer": []}],
                     methods=["DELETE"],
                     parameters=[
                         OpenApiParameter(

--- a/api/swagger/user_mixin_swagger.py
+++ b/api/swagger/user_mixin_swagger.py
@@ -1,8 +1,13 @@
-from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiExample,
+    OpenApiResponse,
+    OpenApiParameter,
+)
 from drf_spectacular.types import OpenApiTypes
 
 
-class UserCreateSwaggerMixin:
+class MasterUserCreateSwaggerMixin:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -65,3 +70,254 @@ class UserCreateSwaggerMixin:
                     )
                 ],
             )(cls.post)
+
+
+class MasterUserListSwaggerMixin:
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "get"):
+            cls.get = extend_schema(
+                tags=["Usuário"],
+                description="Lista todos os usuários master do sistema.",
+                summary="Lista todos os usuários.",
+                auth=[{"Bearer": []}],
+                methods=["GET"],
+                responses={
+                    200: OpenApiResponse(
+                        description="Usuários listados com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "result": [
+                                        {
+                                            "count": 2,
+                                            "next": None,
+                                            "previous": None,
+                                            "results": [
+                                                {
+                                                    "id": 1,
+                                                    "is_superuser": True,
+                                                    "first_name": "Robson",
+                                                    "last_name": "Ferreira",
+                                                    "username": "robson",
+                                                    "name": "Robson Ferreira",
+                                                    "email": "robson12ferreira@gmail.com",
+                                                    "cpf": "09826353469",
+                                                    "cnpj": None,
+                                                    "date_joined": "19-04-2025 12:43",
+                                                    "last_login": "19-04-2025 12:44",
+                                                    "created_at": "19-04-2025 12:43",
+                                                    "updated_at": "19-04-2025 12:43",
+                                                    "is_master": True,
+                                                    "is_company": False,
+                                                    "is_employee": False,
+                                                    "user_type": None,
+                                                    "is_staff": True,
+                                                    "is_active": True,
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "is_superuser": True,
+                                                    "first_name": "Lemmy",
+                                                    "last_name": "Kilmister",
+                                                    "username": "lemmy",
+                                                    "name": "Lemmy Kilmister",
+                                                    "email": "motorhead@gmail.com",
+                                                    "cpf": "12345678900",
+                                                    "cnpj": None,
+                                                    "date_joined": "21-04-2025 09:45",
+                                                    "last_login": "21-04-2025 16:37",
+                                                    "created_at": "21-04-2025 09:45",
+                                                    "updated_at": "21-04-2025 16:37",
+                                                    "is_master": True,
+                                                    "is_company": False,
+                                                    "is_employee": False,
+                                                    "user_type": "master",
+                                                    "is_staff": True,
+                                                    "is_active": True,
+                                                },
+                                            ],
+                                        }
+                                    ]
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+            )(cls.get)
+
+
+class MasterUserUpdateSwaggerMixin:
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if hasattr(cls, "patch"):
+            cls.patch = extend_schema(
+                tags=["Usuário"],
+                description="Atualiza o usuário master.",
+                summary="Atualiza o usuário.",
+                auth=[{"Bearer": []}],
+                methods=["PATCH"],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        location=OpenApiParameter.PATH,
+                        type=OpenApiTypes.UUID,
+                        description="ID do usuário a ser atualizado.",
+                        required=True,
+                    ),
+                ],
+                request=OpenApiTypes.OBJECT,
+                responses={
+                    202: OpenApiResponse(
+                        description="Usuário atualizado com sucesso.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Exemplo de resposta de sucesso",
+                                value={
+                                    "id": 2,
+                                    "is_superuser": True,
+                                    "first_name": "Lemmy",
+                                    "last_name": "Kilmister",
+                                    "username": "lemmy",
+                                    "name": "Lemmy Kilmister",
+                                    "email": "motorhead@gmail.com",
+                                    "cpf": "12345678900",
+                                    "cnpj": None,
+                                    "date_joined": "21-04-2025 09:45",
+                                    "last_login": "21-04-2025 16:37",
+                                    "created_at": "21-04-2025 09:45",
+                                    "updated_at": "21-04-2025 16:37",
+                                    "is_master": True,
+                                    "is_company": False,
+                                    "is_employee": False,
+                                    "user_type": "master",
+                                    "is_staff": True,
+                                    "is_active": True,
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    401: OpenApiResponse(
+                        description="Usuário não autorizado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não autorizado",
+                                value={
+                                    "detail": "Authentication credentials were not provided."
+                                },
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                    404: OpenApiResponse(
+                        description="Usuário não encontrado.",
+                        response=OpenApiTypes.OBJECT,
+                        examples=[
+                            OpenApiExample(
+                                name="Usuário não encontrado",
+                                value={"detail": "Usuário não encontrado."},
+                                response_only=True,
+                            ),
+                        ],
+                    ),
+                },
+                examples=[
+                    OpenApiExample(
+                        name="Exemplo de requisição",
+                        value={
+                            "id": 2,
+                            "is_superuser": True,
+                            "first_name": "Lemmy",
+                            "last_name": "Kilmister",
+                            "username": "lemmy",
+                            "name": "Lemmy Kilmister",
+                            "email": "motorhead@gmail.com",
+                            "cpf": "12345678900",
+                        },
+                        request_only=True,
+                    )
+                ],
+            )(cls.patch)
+
+class MasterUserDeleteSwaggerMixin:
+    
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+    
+            if hasattr(cls, "delete"):
+                cls.delete = extend_schema(
+                    tags=["Usuário"],
+                    description="Deleta o usuário master.",
+                    summary="Deleta o usuário.",
+                    auth=[{"Bearer": []}],
+                    methods=["DELETE"],
+                    parameters=[
+                        OpenApiParameter(
+                            name="id",
+                            location=OpenApiParameter.PATH,
+                            type=OpenApiTypes.UUID,
+                            description="ID do usuário a ser deletado.",
+                            required=True,
+                        ),
+                    ],
+                    responses={
+                        204: OpenApiResponse(
+                            description="Usuário deletado com sucesso.",
+                            response=OpenApiTypes.OBJECT,
+                            examples=[
+                                OpenApiExample(
+                                    name="Exemplo de resposta de sucesso",
+                                    value={},
+                                    response_only=True,
+                                ),
+                            ],
+                        ),
+                        401: OpenApiResponse(
+                            description="Usuário não autorizado.",
+                            response=OpenApiTypes.OBJECT,
+                            examples=[
+                                OpenApiExample(
+                                    name="Usuário não autorizado",
+                                    value={
+                                        "detail": "Authentication credentials were not provided."
+                                    },
+                                    response_only=True,
+                                ),
+                            ],
+                        ),
+                        404: OpenApiResponse(
+                            description="Usuário não encontrado.",
+                            response=OpenApiTypes.OBJECT,
+                            examples=[
+                                OpenApiExample(
+                                    name="Usuário não encontrado",
+                                    value={"detail": "Usuário não encontrado."},
+                                    response_only=True,
+                                ),
+                            ],
+                        ),
+                    },
+                )(cls.delete)

--- a/api/utils/allowed_tags.py
+++ b/api/utils/allowed_tags.py
@@ -5,6 +5,8 @@ def filter_endpoints_by_allowed_tags(result, generator, request, public):
     allowed_tags = {
         'Autenticação',
         'Usuário',
+        'Empresa',
+        'Funcionário',
     }
 
     paths = result['paths']

--- a/api/view/company_view.py
+++ b/api/view/company_view.py
@@ -2,43 +2,54 @@ from rest_framework import generics, permissions
 from api.model.customuser import CustomUser
 from api.permissions import IsMasterUser, IsCompanyOwnerOrMaster
 from api.serializers.company_serializer import CompanyUserSerializer
+from api.swagger.company_mixin_swagger import (
+    CompanyUserCreateSwaggerMixin,
+    CompanyUserDeleteSwaggerMixin,
+    CompanyUserListSwaggerMixin,
+    CompanyUserUpdateSwaggerMixin,
+)
 
-class CompanyUserCreateView(generics.CreateAPIView):
+
+class CompanyUserCreateView(CompanyUserCreateSwaggerMixin, generics.CreateAPIView):
     queryset = CustomUser.objects.filter(is_company=True)
     serializer_class = CompanyUserSerializer
     permission_classes = [permissions.AllowAny]
-    
+
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
-class CompanyUserListView(generics.ListAPIView):
+
+class CompanyUserListView(CompanyUserListSwaggerMixin, generics.ListAPIView):
     queryset = CustomUser.objects.filter(is_company=True)
     serializer_class = CompanyUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsMasterUser]
-    
+
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
+
 
 class CompanyUserDetailView(generics.RetrieveAPIView):
     queryset = CustomUser.objects.filter(is_company=True)
     serializer_class = CompanyUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyOwnerOrMaster]
-    
+
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-class CompanyUserUpdateView(generics.UpdateAPIView):
+
+class CompanyUserUpdateView(CompanyUserUpdateSwaggerMixin, generics.UpdateAPIView):
     queryset = CustomUser.objects.filter(is_company=True)
     serializer_class = CompanyUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyOwnerOrMaster]
-    
+
     def patch(self, request, *args, **kwargs):
         return super().patch(request, *args, **kwargs)
 
-class CompanyUserDeleteView(generics.DestroyAPIView):
+
+class CompanyUserDeleteView(CompanyUserDeleteSwaggerMixin, generics.DestroyAPIView):
     queryset = CustomUser.objects.filter(is_company=True)
     serializer_class = CompanyUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsMasterUser]
-    
+
     def delete(self, request, *args, **kwargs):
         return super().delete(request, *args, **kwargs)

--- a/api/view/employee_transferer_view.py
+++ b/api/view/employee_transferer_view.py
@@ -1,4 +1,4 @@
-from rest_framework import generics, permissions, status
+from rest_framework import generics, permissions
 from rest_framework.response import Response
 from api.model.employee_model import Employee
 from api.permissions.permissions import IsMasterUser

--- a/api/view/employee_transferer_view.py
+++ b/api/view/employee_transferer_view.py
@@ -3,10 +3,11 @@ from rest_framework.response import Response
 from api.model.employee_model import Employee
 from api.permissions.permissions import IsMasterUser
 from api.serializers.employee_transferer_serializer import EmployeeTransferSerializer
+from api.swagger.employee_mixin_swagger import EmployeeTransferSwaggerMixin
 
 
 
-class EmployeeTransferView(generics.UpdateAPIView):
+class EmployeeTransferView(EmployeeTransferSwaggerMixin,generics.UpdateAPIView):
     queryset = Employee.objects.all()
     serializer_class = EmployeeTransferSerializer
     permission_classes = [permissions.IsAuthenticated, IsMasterUser]

--- a/api/view/employee_view.py
+++ b/api/view/employee_view.py
@@ -4,91 +4,106 @@ from api.model.customuser import CustomUser
 from api.serializers.employee_serializer import EmployeeUserSerializer
 from api.permissions import IsCompanyEmployeeOwnerOrMaster
 from api.model.company_model import Company
+from api.swagger.employee_mixin_swagger import (
+    EmployeeUserCreateSwaggerMixin,
+    EmployeeUserDeleteSwaggerMixin,
+    EmployeeUserListSwaggerMixin,
+    EmployeeUserUpdateSwaggerMixin,
+)
 
-class EmployeeUserCreateView(generics.CreateAPIView):
+
+class EmployeeUserCreateView(EmployeeUserCreateSwaggerMixin, generics.CreateAPIView):
     queryset = CustomUser.objects.filter(is_employee=True)
     serializer_class = EmployeeUserSerializer
     permission_classes = [permissions.IsAuthenticated]
-    
+
     def check_permissions(self, request):
         super().check_permissions(request)
-        
+
         # Verificar se o usuário é master ou empresa
         if not (request.user.is_master or request.user.is_company):
             self.permission_denied(
-                request, 
+                request,
                 message="Apenas empresas ou administradores podem criar funcionários.",
-                code="permission_denied"
+                code="permission_denied",
             )
-    
+
     def perform_create(self, serializer):
         # Se for empresa, valida se está criando para sua própria empresa
         if self.request.user.is_company:
             try:
                 company = Company.objects.get(user=self.request.user)
-                company_id = serializer.validated_data.get('company_id')
-                
+                company_id = serializer.validated_data.get("company_id")
+
                 if str(company.id) != str(company_id):
                     raise serializers.ValidationError(
-                        {"company_id": "Você só pode criar funcionários para sua própria empresa"}
+                        {
+                            "company_id": "Você só pode criar funcionários para sua própria empresa"
+                        }
                     )
             except Company.DoesNotExist:
                 raise serializers.ValidationError(
                     {"error": "Seu perfil de empresa não foi encontrado"}
                 )
-        
+
         serializer.save()
-    
+
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
-class EmployeeUserListView(generics.ListAPIView):
+
+class EmployeeUserListView(EmployeeUserListSwaggerMixin, generics.ListAPIView):
     serializer_class = EmployeeUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyEmployeeOwnerOrMaster]
     filter_backends = [filters.SearchFilter]
-    search_fields = ['username', 'name', 'email', 'employee_profile__nome']
-    
+    search_fields = ["username", "name", "email", "employee_profile__nome"]
+
     def get_queryset(self):
         queryset = CustomUser.objects.filter(is_employee=True)
-        
+
         # Se for master, pode ver todos os funcionários
         if self.request.user.is_master:
             return queryset
-            
+
         # Se for empresa, só vê seus funcionários
-        if self.request.user.is_company and hasattr(self.request.user, 'company_profile'):
+        if self.request.user.is_company and hasattr(
+            self.request.user, "company_profile"
+        ):
             company_id = self.request.user.company_profile.id
             return queryset.filter(employee_profile__company__id=company_id)
-            
+
         # Se for funcionário, só vê a si mesmo
         if self.request.user.is_employee:
             return queryset.filter(id=self.request.user.id)
-            
+
         return CustomUser.objects.none()
-    
+
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
+
 
 class EmployeeUserDetailView(generics.RetrieveAPIView):
     queryset = CustomUser.objects.filter(is_employee=True)
     serializer_class = EmployeeUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyEmployeeOwnerOrMaster]
-    
+
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-class EmployeeUserUpdateView(generics.UpdateAPIView):
+
+class EmployeeUserUpdateView(EmployeeUserUpdateSwaggerMixin, generics.UpdateAPIView):
     queryset = CustomUser.objects.filter(is_employee=True)
     serializer_class = EmployeeUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyEmployeeOwnerOrMaster]
-    
+
     def patch(self, request, *args, **kwargs):
         return super().patch(request, *args, **kwargs)
 
-class EmployeeUserDeleteView(generics.DestroyAPIView):
+
+class EmployeeUserDeleteView(EmployeeUserDeleteSwaggerMixin, generics.DestroyAPIView):
     queryset = CustomUser.objects.filter(is_employee=True)
     serializer_class = EmployeeUserSerializer
     permission_classes = [permissions.IsAuthenticated, IsCompanyEmployeeOwnerOrMaster]
-    
+
     def delete(self, request, *args, **kwargs):
         return super().delete(request, *args, **kwargs)

--- a/api/view/employee_view.py
+++ b/api/view/employee_view.py
@@ -2,8 +2,7 @@ from rest_framework import generics, permissions, filters
 from api import serializers
 from api.model.customuser import CustomUser
 from api.serializers.employee_serializer import EmployeeUserSerializer
-from api.permissions import IsMasterUser, IsCompanyUser, IsCompanyEmployeeOwnerOrMaster
-from django.shortcuts import get_object_or_404
+from api.permissions import IsCompanyEmployeeOwnerOrMaster
 from api.model.company_model import Company
 
 class EmployeeUserCreateView(generics.CreateAPIView):

--- a/api/view/user_view.py
+++ b/api/view/user_view.py
@@ -1,36 +1,45 @@
 from rest_framework import generics, permissions
 from api.model.customuser import CustomUser
 from api.serializers import MasterUserSerializer
-from api.swagger.user_mixin_swagger import MasterUserCreateSwaggerMixin, MasterUserDeleteSwaggerMixin, MasterUserListSwaggerMixin, MasterUserUpdateSwaggerMixin
+from api.swagger.user_mixin_swagger import (
+    MasterUserCreateSwaggerMixin,
+    MasterUserDeleteSwaggerMixin,
+    MasterUserListSwaggerMixin,
+    MasterUserUpdateSwaggerMixin,
+)
 
-class MasterUserCreateView(MasterUserCreateSwaggerMixin,generics.CreateAPIView):
+
+class MasterUserCreateView(MasterUserCreateSwaggerMixin, generics.CreateAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.AllowAny]
-    
+
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
-class MasterUserListView(MasterUserListSwaggerMixin,generics.ListAPIView):
+
+class MasterUserListView(MasterUserListSwaggerMixin, generics.ListAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]
-    
+
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-class MasterUserUpdateView(MasterUserUpdateSwaggerMixin,generics.UpdateAPIView):
+
+class MasterUserUpdateView(MasterUserUpdateSwaggerMixin, generics.UpdateAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]
-    
+
     def patch(self, request, *args, **kwargs):
         return super().patch(request, *args, **kwargs)
 
-class MasterUserDeleteView(MasterUserDeleteSwaggerMixin,generics.DestroyAPIView):
+
+class MasterUserDeleteView(MasterUserDeleteSwaggerMixin, generics.DestroyAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]
-    
+
     def delete(self, request, *args, **kwargs):
         return super().delete(request, *args, **kwargs)

--- a/api/view/user_view.py
+++ b/api/view/user_view.py
@@ -1,9 +1,9 @@
 from rest_framework import generics, permissions
 from api.model.customuser import CustomUser
 from api.serializers import MasterUserSerializer
-from api.swagger.user_mixin_swagger import UserCreateSwaggerMixin
+from api.swagger.user_mixin_swagger import MasterUserCreateSwaggerMixin, MasterUserDeleteSwaggerMixin, MasterUserListSwaggerMixin, MasterUserUpdateSwaggerMixin
 
-class MasterUserCreateView(UserCreateSwaggerMixin,generics.CreateAPIView):
+class MasterUserCreateView(MasterUserCreateSwaggerMixin,generics.CreateAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.AllowAny]
@@ -11,7 +11,7 @@ class MasterUserCreateView(UserCreateSwaggerMixin,generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
-class MasterUserListView(generics.ListAPIView):
+class MasterUserListView(MasterUserListSwaggerMixin,generics.ListAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]
@@ -19,7 +19,7 @@ class MasterUserListView(generics.ListAPIView):
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-class MasterUserUpdateView(generics.UpdateAPIView):
+class MasterUserUpdateView(MasterUserUpdateSwaggerMixin,generics.UpdateAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]
@@ -27,7 +27,7 @@ class MasterUserUpdateView(generics.UpdateAPIView):
     def patch(self, request, *args, **kwargs):
         return super().patch(request, *args, **kwargs)
 
-class MasterUserDeleteView(generics.DestroyAPIView):
+class MasterUserDeleteView(MasterUserDeleteSwaggerMixin,generics.DestroyAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = MasterUserSerializer
     permission_classes = [permissions.IsAdminUser]

--- a/api/view/user_view.py
+++ b/api/view/user_view.py
@@ -1,4 +1,5 @@
 from rest_framework import generics, permissions
+from rest_framework.response import Response
 from api.model.customuser import CustomUser
 from api.serializers import MasterUserSerializer
 from api.swagger.user_mixin_swagger import (
@@ -15,7 +16,32 @@ class MasterUserCreateView(MasterUserCreateSwaggerMixin, generics.CreateAPIView)
     permission_classes = [permissions.AllowAny]
 
     def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
+        try:
+            response = super().post(request, *args, **kwargs)
+            user_data = response.data
+            return Response(
+                {
+                    "message": "Usuário criado com sucesso",
+                    "result": {
+                        "id": user_data["id"],
+                        "first_name": user_data["first_name"],
+                        "last_name": user_data["last_name"],
+                        "username": user_data["username"],
+                        "name": user_data["name"],
+                        "email": user_data["email"],
+                        "cpf": user_data["cpf"],
+                        "date_joined": user_data["date_joined"],
+                        "created_at": user_data["created_at"],
+                        "is_superuser": user_data["is_superuser"],
+                        "is_master": user_data["is_master"],
+                    },
+                },
+                status=201,
+            )
+        except Exception as e:
+            return Response(
+                {"message": "Erro ao criar usuário", "error": str(e)}, status=400
+            )
 
 
 class MasterUserListView(MasterUserListSwaggerMixin, generics.ListAPIView):

--- a/core/settings.py
+++ b/core/settings.py
@@ -208,6 +208,8 @@ SPECTACULAR_SETTINGS = {
     'TAGS': [
         {'name': 'Autenticação', 'description': 'Configurações referentes a autenticação e autorização'},
         {'name': 'Usuário', 'description': 'Configurações referentes aos usuários do sistema'},
+        {'name': 'Empresa', 'description': 'Configurações referentes às empresas do sistema'},
+        {'name': 'Funcionário', 'description': 'Configurações referentes aos funcionários do sistema'},
     ],
     'SORT_OPERATIONS': False,  
     'ENUM_NAME_OVERRIDES': {},  


### PR DESCRIPTION
# Task #7 

This pull request introduces significant updates to the Swagger mixins for API documentation, focusing on expanding functionality for user, company, and employee endpoints. The changes include adding new mixins for CRUD operations, enhancing authentication details, and providing detailed response examples for better API clarity.

### Enhancements to Swagger Mixins:

#### User Mixins:
* Renamed `UserCreateSwaggerMixin` to `MasterUserCreateSwaggerMixin` and updated it to include authentication details (`auth=[{"Bearer": []}]`) and a more detailed success response example. [[1]](diffhunk://#diff-a53947b09745ab92e50d7e150aff4b063e1af8070d5427679ed44631273a0f71L1-R18) [[2]](diffhunk://#diff-a53947b09745ab92e50d7e150aff4b063e1af8070d5427679ed44631273a0f71L25-R44)

#### Company Mixins:
* Added new mixins for company-related operations (`CompanyUserCreateSwaggerMixin`, `CompanyUserListSwaggerMixin`, `CompanyUserUpdateSwaggerMixin`, `CompanyUserDeleteSwaggerMixin`) with detailed request and response schemas, including examples for success and error cases.

#### Employee Mixins:
* Introduced new mixins for employee-related operations (`EmployeeUserCreateSwaggerMixin`, `EmployeeUserListSwaggerMixin`, `EmployeeUserUpdateSwaggerMixin`, `EmployeeUserDeleteSwaggerMixin`, `EmployeeTransferSwaggerMixin`) to handle CRUD functionality and employee transfers.

### General Improvements:
* Updated the `__init_subclass__` method in `authentication_mixin_swagger.py` to include authentication details (`auth=[{"Bearer": []}]`) for the logout endpoint.
* Refactored imports in `api/swagger/__init__.py` to include all new mixins and updated the `__All__` list accordingly.